### PR TITLE
CONSOLE-4440: Utilization section in the Overview page of Node details is misaligned and scrollable and misaligned ticks.

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationBody.tsx
@@ -23,7 +23,7 @@ const UtilizationAxis: React.FC = () => {
         orientation="top"
         height={15}
         width={width}
-        padding={{ top: 30, bottom: 0, left: 70, right: 0 }}
+        padding={{ top: 31, bottom: 0, left: 70, right: 0 }}
         style={{
           axis: { visibility: 'hidden' },
         }}

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/utilization-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/utilization-card.scss
@@ -1,5 +1,6 @@
 .co-utilization-card__body {
   padding: 0;
+  overflow: hidden;
 }
 
 .co-utilization-card__item .co-u-hidden {
@@ -41,6 +42,7 @@
 
 .co-utilization-card__item-section {
   width: 100%;
+  overflow: hidden;
 }
 
 .co-utilization-card__item-section-multiline {


### PR DESCRIPTION
Hiding the overflow on the Utilization card and content resolved the issue with the appearing scroll bar.

Before (scrollable Utilization section):


https://github.com/user-attachments/assets/e214744c-55bf-4275-8ab8-dfdf0be9086e


Before (Misaligned ticks on horizontal line):

<img width="688" alt="Screenshot 2025-01-15 at 18 39 25" src="https://github.com/user-attachments/assets/c6417315-b45c-4dbd-be6d-9aa60cbe3a65" />

After (scrollable Utilization section):


https://github.com/user-attachments/assets/1abc04ad-b6d9-40cd-9875-28aa426875a3


After (Misaligned ticks on horizontal line) and compared to PF5:
<img width="1512" alt="Screenshot 2025-01-15 at 18 49 07" src="https://github.com/user-attachments/assets/796becee-97dc-420c-8525-bf46b11496fa" />

