### PR TITLE
CONSOLE-4431: Fix operator install status background color

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -282,7 +282,6 @@ $co-affinity-row-margin: 15px;
 }
 
 .co-operator-install-page__main {
-  background-color: var(--pf-t--color--gray--10);
   height: 100%;
 }
 


### PR DESCRIPTION
Remove "background-color" style from 'co-operator-install-page__main' class.