### PR TITLE
Fix: missing guided tour spotlight token

### DIFF
--- a/frontend/packages/console-shared/src/components/spotlight/spotlight.scss
+++ b/frontend/packages/console-shared/src/components/spotlight/spotlight.scss
@@ -28,7 +28,7 @@
 }
 
 @mixin ocs-spotlight-outline {
-  outline: 4px solid var(--pf-t--global--border--color--nonstatus--blue--default);
+  outline: 4px solid var(--pf-t--global--color--nonstatus--blue--default);
   outline-offset: 4px;
 }
 
@@ -39,9 +39,7 @@
     mix-blend-mode: hard-light;
   }
   &__element-highlight-noanimate {
-    border: var(--pf-t--global--border--width--xl) solid
-      var(--pf-t--global--color--nonstatus--blue--default);
-    background-color: var(--pf-t--color--gray--50);
+    border: var(--pf-t--global--border--width--extra-strong) solid var(--pf-t--global--color--nonstatus--blue--default); 
     z-index: 9999;
   }
   &__element-highlight-animate {


### PR DESCRIPTION
Currently using a nonstatus blue token. If the aim is to have the color match the overall branding, then this token should be updated to the brand color token.

Before:
![Screenshot From 2025-01-10 19-19-53](https://github.com/user-attachments/assets/86206ad2-721c-4a7e-b2d5-434ff5a1b06b)

After:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/52b45546-948f-4662-8cd4-5bb8f1e05c92" />

V5:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/25131906-e945-4eeb-9c87-977e921c7c9f" />

