### PR TITLE
Fixed helm release history action menu text wrap issue

### DIFF
--- a/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
+++ b/frontend/packages/console-shared/src/components/actions/menu/ActionMenu.tsx
@@ -13,6 +13,7 @@ type ActionMenuProps = {
   isDisabled?: boolean;
   variant?: ActionMenuVariant;
   label?: string;
+  className?: string;
 };
 
 const ActionMenu: React.FC<ActionMenuProps> = ({
@@ -21,6 +22,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   isDisabled,
   variant = ActionMenuVariant.KEBAB,
   label,
+  className,
 }) => {
   const isKebabVariant = variant === ActionMenuVariant.KEBAB;
   const [isVisible, setVisible] = useSafetyFirst(isKebabVariant);
@@ -76,7 +78,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   const menu = (
     <Menu ref={menuRef} containsFlyout onSelect={hideMenu}>
       <MenuContent data-test-id="action-items">
-        <MenuList>
+        <MenuList className={className}>
           <ActionMenuContent options={menuOptions} onClick={hideMenu} focusItem={menuOptions[0]} />
         </MenuList>
       </MenuContent>

--- a/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.scss
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.scss
@@ -1,0 +1,3 @@
+.helm-release-history-action-menu {
+  width: max-content;
+}

--- a/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/HelmReleaseHistoryRow.tsx
@@ -9,6 +9,7 @@ import { ActionMenu, Status } from '@console/shared';
 import { HelmRelease } from '../../../types/helm-types';
 import { HelmReleaseStatusLabels, releaseStatus } from '../../../utils/helm-utils';
 import { tableColumnClasses } from './HelmReleaseHistoryHeader';
+import './HelmReleaseHistoryRow.scss';
 
 type HelmReleaseHistoryKebabProps = {
   obj: HelmRelease;
@@ -52,7 +53,7 @@ const confirmModalRollbackHelmRelease = (
 const HelmReleaseHistoryKebab: React.FC<HelmReleaseHistoryKebabProps> = ({ obj }) => {
   const { t } = useTranslation();
   const menuActions = [confirmModalRollbackHelmRelease(obj.name, obj.namespace, obj.version, t)];
-  return <ActionMenu actions={menuActions} />;
+  return <ActionMenu actions={menuActions} className="helm-release-history-action-menu" />;
 };
 
 const HelmReleaseHistoryRow: React.FC<RowFunctionArgs> = ({ obj, customData }) => (


### PR DESCRIPTION
Before:

https://drive.google.com/file/d/1uEBzlJYhlAWJix9-9IY-7sPQALdfjV_D/view?usp=drive_link

After:


https://github.com/user-attachments/assets/84e3ca98-f901-48bd-8aca-5a6cf857e859

