### PR TITLE
Fixed pod size issue in functions details page

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewListItem.scss
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewListItem.scss
@@ -2,7 +2,7 @@
   padding: var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--lg)
     var(--pf-t--global--spacer--sm);
   &__pod {
-    width: var(--pf-t--global--icon--size--lg);
+    width: var(--pf-t--global--icon--size--xl);
     cursor: default;
   }
 }


### PR DESCRIPTION
Before:

<img width="1382" alt="Screenshot 2025-01-16 at 2 50 41 PM" src="https://github.com/user-attachments/assets/1306150f-6fa2-4055-b5e9-bde428f71294" />

After:

<img width="1386" alt="Screenshot 2025-01-16 at 2 52 24 PM" src="https://github.com/user-attachments/assets/aeb507f4-fd3e-400d-960a-0d018e2a75cb" />
