### PR TITLE
Fix: data list checkboxes, col management button position

### DIFF
--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -191,7 +191,7 @@ export const ModalSubmitFooter: React.FC<ModalSubmitFooterProps> = ({
   );
 
   const resetButton = (
-    <Button variant="link" isInline onClick={onResetClick} id="reset-action">
+    <Button variant="link" onClick={onResetClick} id="reset-action">
       {resetText || t('public~Reset')}
     </Button>
   );

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -114,3 +114,9 @@
 .modal-paragraph {
   margin-bottom: var(--pf-v6-c-content--MarginBottom);
 }
+
+.co-datalist {
+  label{
+    margin-bottom: 0;
+  }
+}

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -114,9 +114,3 @@
 .modal-paragraph {
   margin-bottom: var(--pf-v6-c-content--MarginBottom);
 }
-
-.co-datalist {
-  label{
-    margin-bottom: 0;
-  }
-}

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -37,6 +37,7 @@ const DataListRow: React.FC<DataListRowProps> = ({
   >
     <DataListItemRow>
       <DataListCheck
+        className="co-datalist-control"
         isDisabled={
           (disableUncheckedRow && !checkedColumns.has(column.id)) || readOnlyColumns.has(column.id)
         }
@@ -128,7 +129,6 @@ export const ColumnManagementModal: React.FC<
                 {t('public~Default {{resourceKind}} columns', { resourceKind: columnLayout.type })}
               </label>
               <DataList
-                className="co-datalist"
                 aria-label={t('public~Default column list')}
                 id="defalt-column-management"
                 isCompact
@@ -147,7 +147,6 @@ export const ColumnManagementModal: React.FC<
             <span className="col-sm-6">
               <label className="control-label">{t('public~Additional columns')}</label>
               <DataList
-                className="co-datalist"
                 aria-label={t('public~Additional column list')}
                 id="additional-column-management"
                 isCompact

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -128,6 +128,7 @@ export const ColumnManagementModal: React.FC<
                 {t('public~Default {{resourceKind}} columns', { resourceKind: columnLayout.type })}
               </label>
               <DataList
+                className="co-datalist"
                 aria-label={t('public~Default column list')}
                 id="defalt-column-management"
                 isCompact
@@ -146,6 +147,7 @@ export const ColumnManagementModal: React.FC<
             <span className="col-sm-6">
               <label className="control-label">{t('public~Additional columns')}</label>
               <DataList
+                className="co-datalist"
                 aria-label={t('public~Additional column list')}
                 id="additional-column-management"
                 isCompact

--- a/frontend/public/components/modals/column-management-modal.tsx
+++ b/frontend/public/components/modals/column-management-modal.tsx
@@ -41,7 +41,7 @@ const DataListRow: React.FC<DataListRowProps> = ({
           (disableUncheckedRow && !checkedColumns.has(column.id)) || readOnlyColumns.has(column.id)
         }
         aria-labelledby={`table-column-management-item-${column.id}`}
-        checked={checkedColumns.has(column.id)}
+        isChecked={checkedColumns.has(column.id)}
         name={column.title}
         id={column.id}
         onChange={onChange}

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -84,6 +84,13 @@ form.pf-v6-c-form {
   vertical-align: top; // PF defaults to baseline which doesn't align correctly when Operator logos are within the table
 }
 
+// Overrides bootstrap label margin for DataListCheck's internal checkbox labels
+.co-datalist-control {
+  label{
+    margin-bottom: 0;
+  }
+}
+
 .co-toolbar-empty-state .pf-v6-c-toolbar__content {
   --pf-v6-c-toolbar__content--PaddingLeft: 0;
   --pf-v6-c-toolbar__content--PaddingRight: 0;
@@ -325,11 +332,4 @@ ul {
 
 .pf-v6-c-truncate--no-min-width {
   --pf-v6-c-truncate--MinWidth: 0 !important;
-}
-
-// Overrides bootstrap label margin for DataListCheck's internal checkbox labels
-.co-datalist-control {
-  label{
-    margin-bottom: 0;
-  }
 }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -326,3 +326,10 @@ ul {
 .pf-v6-c-truncate--no-min-width {
   --pf-v6-c-truncate--MinWidth: 0 !important;
 }
+
+// Overrides bootstrap label margin for DataListCheck's internal checkbox labels
+.co-datalist-control {
+  label{
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
DataListCheck in PF6 uses `isChecked` after internally switching to using `Checkbox`. Might be an upstream issue still because I think `checked` should have still worked, will have to investigate. The reset button in the modal doesn't need to be an inline button, removing that modifier fixes the position.

Before:
![ManageColumnsModalAfterPF6](https://github.com/user-attachments/assets/10c466a1-d56f-4099-99b0-86e5743036bc)

After:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/1ec142d5-71f3-42c0-bb5d-b21dd015f1e7" />

V5:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/90486497-b2c5-4188-9fb5-f8180e47cbbe" />
