### PR TITLE
Fix Topology view switcher button icon alignment

### DIFF
--- a/frontend/packages/topology/src/components/page/TopologyView.scss
+++ b/frontend/packages/topology/src/components/page/TopologyView.scss
@@ -29,13 +29,6 @@
     pointer-events: none;
   }
 
-  &__view-switcher.pf-m-plain {
-    @media (min-width: 768px) {
-      padding-bottom: 4px;
-      padding-right: 2px;
-    }
-  }
-
   &__layout-group {
     display: flex;
     align-items: center;


### PR DESCRIPTION
**Before:**
<img width="376" alt="image" src="https://github.com/user-attachments/assets/1b7f5910-6dff-478a-960f-d32418e1bca3" />

**After:**
<img width="371" alt="image" src="https://github.com/user-attachments/assets/0227b867-0799-42f0-8fc3-5ab854c677c7" />
