### PR TITLE
fix: masthead a11y alt text

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -346,6 +346,5 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -346,5 +346,6 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/frontend/public/components/masthead.jsx
+++ b/frontend/public/components/masthead.jsx
@@ -41,8 +41,8 @@ export const Masthead = React.memo(({ isMastheadStacked, isNavOpen, onNavToggle 
           <MastheadLogo
             data-codemods
             component="a"
-            {...logoProps}
             aria-label={window.SERVER_FLAGS.customLogoURL ? undefined : details.productName}
+            {...logoProps}
           >
             {window.SERVER_FLAGS.customLogoURL ? (
               <Brand src={details.logoImg} alt={details.productName} data-test="brand-image" />

--- a/frontend/public/components/masthead.jsx
+++ b/frontend/public/components/masthead.jsx
@@ -37,9 +37,8 @@ export const Masthead = React.memo(({ isMastheadStacked, isNavOpen, onNavToggle 
             <BarsIcon />
           </PageToggleButton>
         </MastheadToggle>
-        <MastheadBrand data-codemods>
+        <MastheadBrand>
           <MastheadLogo
-            data-codemods
             component="a"
             aria-label={window.SERVER_FLAGS.customLogoURL ? undefined : details.productName}
             {...logoProps}

--- a/frontend/public/components/masthead.jsx
+++ b/frontend/public/components/masthead.jsx
@@ -37,12 +37,22 @@ export const Masthead = React.memo(({ isMastheadStacked, isNavOpen, onNavToggle 
             <BarsIcon />
           </PageToggleButton>
         </MastheadToggle>
-        <MastheadBrand>
-          <MastheadLogo component="a" {...logoProps}>
+        <MastheadBrand data-codemods>
+          <MastheadLogo
+            data-codemods
+            component="a"
+            {...logoProps}
+            aria-label={window.SERVER_FLAGS.customLogoURL ? undefined : details.productName}
+          >
             {window.SERVER_FLAGS.customLogoURL ? (
               <Brand src={details.logoImg} alt={details.productName} data-test="brand-image" />
             ) : (
-              <ReactSVG src={details.logoImg} data-test="brand-image" className="pf-v6-c-brand" />
+              <ReactSVG
+                src={details.logoImg}
+                aria-hidden
+                data-test="brand-image"
+                className="pf-v6-c-brand"
+              />
             )}
           </MastheadLogo>
         </MastheadBrand>


### PR DESCRIPTION
Fixes two a11y issues coming from masthead - that accessible text wasn't being detected for MastheadLogo, and the svg added by `ReactSVG` had no accessible text. 

`ReactSVG` being wrapped in a `div` seems to be causing the problem, preventing detection of any accessible text for the MastheadLogo even after adding it. Since it looks like that wrapper can't be removed, I've instead adjusted the MastheadLogo to include an aria-label in the case that `ReactSVG` is used, and added `aria-hidden` the svg.