### PR TITLE
Donut chart label misalignment in Insights popover

### DIFF
--- a/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
+++ b/frontend/packages/insights-plugin/src/components/InsightsPopup/index.tsx
@@ -46,7 +46,12 @@ const LabelComponent = ({ clusterID, ...props }) => (
 );
 
 const SubTitleComponent = (props) => (
-  <ChartLabel {...props} style={{ fill: 'var(--pf-v6-chart-color-black-500)' }} />
+  <ChartLabel
+    {...props}
+    x={220}
+    y={100}
+    style={{ fill: 'var(--pf-t--chart--color--black--500)' }}
+  />
 );
 
 export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses, k8sResult }) => {
@@ -115,6 +120,7 @@ export const InsightsPopup: React.FC<PrometheusHealthPopupProps> = ({ responses,
                 y: v,
               }))}
               title={`${numberOfIssues}`}
+              titleComponent={<ChartLabel x={220} y={78} />}
               subTitle={t('insights-plugin~Total issue', { count: numberOfIssues })}
               legendOrientation="vertical"
               width={320}


### PR DESCRIPTION
### Before:
<img width="1553" alt="Screenshot 2025-01-21 at 4 58 13 PM" src="https://github.com/user-attachments/assets/e0dca6e8-23e2-4721-9c83-264472d8179e" />

### After:
<img width="1317" alt="Screenshot 2025-01-21 at 4 58 24 PM" src="https://github.com/user-attachments/assets/13e7c44c-f012-424e-9afb-784bae6032e8" />
