### PR TITLE
CONSOLE-4432: Correct operator install modal body scroll

### DIFF
--- a/frontend/packages/console-shared/src/components/modal/Modal.tsx
+++ b/frontend/packages/console-shared/src/components/modal/Modal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { ModalProps as PfModalProps } from '@patternfly/react-core';
-import { Modal as PfModal } from '@patternfly/react-core/deprecated';
+import { Modal as PfModal, ModalProps as PfModalProps } from '@patternfly/react-core/deprecated';
 import * as cx from 'classnames';
 import './Modal.scss';
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -614,68 +614,69 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
           aria-labelledby="catalog-item-header"
           isOpen={!!detailsItem && showDetails}
           onClose={closeOverlay}
-        >
-          <>
-            <CatalogItemHeader
-              className="co-catalog-page__overlay-header"
-              iconClass={detailsItem.iconClass}
-              iconImg={detailsItem.imgUrl}
-              title={titleAndDeprecatedPackage()}
-              vendor={t('olm~{{version}} provided by {{provider}}', {
-                version: updateVersion || installVersion || detailsItem.version,
-                provider: detailsItem.provider,
-              })}
-              data-test-id="operator-modal-header"
-              id="catalog-item-header"
-            />
+          title={detailsItem.name}
+          header={
+            <>
+              <CatalogItemHeader
+                className="co-catalog-page__overlay-header"
+                iconClass={detailsItem.iconClass}
+                iconImg={detailsItem.imgUrl}
+                title={titleAndDeprecatedPackage()}
+                vendor={t('olm~{{version}} provided by {{provider}}', {
+                  version: updateVersion || installVersion || detailsItem.version,
+                  provider: detailsItem.provider,
+                })}
+                data-test-id="operator-modal-header"
+                id="catalog-item-header"
+              />
 
-            <div className="co-catalog-page__overlay-actions">
-              {remoteWorkflowUrl && (
-                <ExternalLink
-                  additionalClassName="pf-v6-c-button pf-m-primary co-catalog-page__overlay-action co-catalog-page__overlay-action--external"
-                  href={remoteWorkflowUrl}
-                  text={
-                    <>
+              <div className="co-catalog-page__overlay-actions">
+                {remoteWorkflowUrl && (
+                  <ExternalLink
+                    additionalClassName="pf-v5-c-button pf-m-primary co-catalog-page__overlay-action co-catalog-page__overlay-action--external"
+                    href={remoteWorkflowUrl}
+                    text={
                       <div className="co-catalog-page__overlay-action-label">
                         {detailsItem.marketplaceActionText || t('olm~Purchase')}
                       </div>
-                    </>
-                  }
-                />
-              )}
-              {!detailsItem.installed ? (
-                <Link
-                  className={classNames(
-                    'pf-v6-c-button',
-                    {
-                      'pf-m-secondary': remoteWorkflowUrl,
-                    },
-                    {
-                      'pf-m-primary': !remoteWorkflowUrl,
-                    },
-                    {
-                      'pf-m-disabled': !detailsItem.obj || detailsItem.isInstalling,
-                    },
-                    'co-catalog-page__overlay-action',
-                  )}
-                  data-test-id="operator-install-btn"
-                  to={installLink}
-                >
-                  {t('olm~Install')}
-                </Link>
-              ) : (
-                <Button
-                  className="co-catalog-page__overlay-action"
-                  data-test-id="operator-uninstall-btn"
-                  isDisabled={!detailsItem.installed}
-                  onClick={() => history.push(uninstallLink())}
-                  variant="secondary"
-                >
-                  {t('olm~Uninstall')}
-                </Button>
-              )}
-            </div>
-          </>
+                    }
+                  />
+                )}
+                {!detailsItem.installed ? (
+                  <Link
+                    className={classNames(
+                      'pf-v5-c-button',
+                      {
+                        'pf-m-secondary': remoteWorkflowUrl,
+                      },
+                      {
+                        'pf-m-primary': !remoteWorkflowUrl,
+                      },
+                      {
+                        'pf-m-disabled': !detailsItem.obj || detailsItem.isInstalling,
+                      },
+                      'co-catalog-page__overlay-action',
+                    )}
+                    data-test-id="operator-install-btn"
+                    to={installLink}
+                  >
+                    {t('olm~Install')}
+                  </Link>
+                ) : (
+                  <Button
+                    className="co-catalog-page__overlay-action"
+                    data-test-id="operator-uninstall-btn"
+                    isDisabled={!detailsItem.installed}
+                    onClick={() => history.push(uninstallLink())}
+                    variant="secondary"
+                  >
+                    {t('olm~Uninstall')}
+                  </Button>
+                )}
+              </div>
+            </>
+          }
+        >
           <OperatorHubItemDetails
             item={detailsItem}
             updateChannel={updateChannel}


### PR DESCRIPTION
Revert initial changes to the console shared Modal and operator hub install modal so that markup structure maintains existing scroll behavior.