### PR TITLE
Set maxMenuHeight and isScrollable for operator install menus so they don't overflow outside the page container

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-channel-version-select.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-channel-version-select.tsx
@@ -85,6 +85,8 @@ export const OperatorChannelSelect: React.FC<OperatorChannelSelectProps> = ({
         selected={selectedUpdateChannel || '-'}
         onOpenChange={(isOpen) => setIsChannelSelectOpen(isOpen)}
         isOpen={isChannelSelectOpen}
+        maxMenuHeight
+        isScrollable
       >
         <SelectList>{channelSelectOptions}</SelectList>
       </Select>
@@ -185,6 +187,8 @@ export const OperatorVersionSelect: React.FC<OperatorVersionSelectProps> = ({
         selected={selectedUpdateVersion}
         onOpenChange={(isOpen) => setIsVersionSelectOpen(isOpen)}
         isOpen={isVersionSelectOpen}
+        maxMenuHeight
+        isScrollable
       >
         <SelectList>{versionSelectOptions}</SelectList>
       </Select>


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/CONSOLE-4449

**After**
![Screenshot 2025-01-23 at 11 37 17 AM](https://github.com/user-attachments/assets/f8b66acc-e661-4940-9cfd-f8bbf485c83e)
