### PR TITLE
CONSOLE-4455: Operator hub empty state spacing is weird

### DIFF
--- a/frontend/packages/console-shared/src/components/empty-state/ConsoleEmptyState.tsx
+++ b/frontend/packages/console-shared/src/components/empty-state/ConsoleEmptyState.tsx
@@ -17,7 +17,7 @@ export const ConsoleEmptyState: React.FC<ConsoleEmptyStateProps> = ({
   ...props
 }) => {
   const dataTest = props['data-test'] || 'console-empty-state';
-  const variant = props.variant || EmptyStateVariant.xs;
+  const variant = props.variant || EmptyStateVariant.sm;
   const body = children && (
     <EmptyStateBody data-test={`${dataTest}-body`}>{children}</EmptyStateBody>
   );
@@ -36,7 +36,14 @@ export const ConsoleEmptyState: React.FC<ConsoleEmptyStateProps> = ({
     </EmptyStateFooter>
   );
   return (
-    <EmptyState variant={variant} data-test={dataTest} titleText={title} icon={Icon} {...props}>
+    <EmptyState
+      className="pf-v6-u-pt-xl-on-md"
+      variant={variant}
+      data-test={dataTest}
+      titleText={title}
+      icon={Icon}
+      {...props}
+    >
       {body}
       {footer}
     </EmptyState>


### PR DESCRIPTION
The spacing on the `ConsoleEmptyState` was a bit off, increasing the padding and making the container (xs -> sm) a little bit bigger will allow the text to be wrapped less frequently.
Before:
<img width="1151" alt="Screenshot 2025-01-27 at 15 54 26" src="https://github.com/user-attachments/assets/1d7e4c0a-a9e6-446d-becd-c2f9267ea508" />

<img width="1148" alt="Screenshot 2025-01-27 at 15 53 56" src="https://github.com/user-attachments/assets/46e00312-0696-4727-9b55-20f875ee04e2" />

After:
<img width="1145" alt="Screenshot 2025-01-27 at 15 55 04" src="https://github.com/user-attachments/assets/19a78d53-7ab4-4b16-817d-9dd9fa321a7b" />
<img width="1151" alt="Screenshot 2025-01-27 at 15 53 34" src="https://github.com/user-attachments/assets/3ae07450-964d-406d-a2ba-efecadf2b68f" />

