### PR TITLE
Overview scrollable cards leak text that should be underneath the border, removal of the scroll fade out gradient.

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/ActivityCard.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/ActivityCard.tsx
@@ -37,7 +37,7 @@ const ActivityCard: React.FC = () => {
   const eventsLink = `${resourcePathFromModel(NodeModel, obj.metadata.name)}/events`;
   const { t } = useTranslation();
   return (
-    <Card data-test-id="activity-card" className="co-overview-card--gradient">
+    <Card data-test-id="activity-card">
       <CardHeader
         actions={{
           actions: (

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/StatusCard.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/StatusCard.tsx
@@ -11,7 +11,7 @@ const StatusCard: React.FC = () => {
   const { obj } = React.useContext(NodeDashboardContext);
   const { t } = useTranslation();
   return (
-    <Card data-test-id="status-card" className="co-overview-card--gradient">
+    <Card data-test-id="status-card">
       <CardHeader>
         <CardTitle>{t('console-app~Status')}</CardTitle>
       </CardHeader>

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -3,6 +3,8 @@
 .co-status-card__alerts-body {
   border-top: var(--pf-t--global--border--width--divider--default) solid
     var(--pf-t--global--border--color--default);
+  /* cuts off 1 pixel at the bottom of the status alerts container - fixes scrollable content leaks on border */
+  clip-path: inset(0 0 1px 0);
   max-height: 19rem;
   min-height: 6rem;
   overflow-x: hidden;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/EventsCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/EventsCard.tsx
@@ -75,7 +75,7 @@ const EventsCard: React.FC<EventsCardProps> = ({
   const hostStatus = getBareMetalHostStatus(obj);
 
   return (
-    <Card className="co-overview-card--gradient">
+    <Card>
       <CardHeader
         actions={{
           actions: (

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
@@ -90,7 +90,7 @@ const HealthCard: React.FC<HealthCardProps> = ({
   const restartScheduled = isHostScheduledForRestart(obj);
 
   return (
-    <Card className="co-overview-card--gradient">
+    <Card>
       <CardHeader>
         <CardTitle>Status</CardTitle>
       </CardHeader>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/activity-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/activity-card.tsx
@@ -194,7 +194,7 @@ const OngoingActivity = connect(mapStateToProps)(
 export const ActivityCard: React.FC<{}> = React.memo(() => {
   const { t } = useTranslation();
   return (
-    <Card data-test-id="activity-card" className="co-overview-card--gradient">
+    <Card data-test-id="activity-card">
       <CardHeader
         actions={{
           actions: (

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -229,7 +229,7 @@ export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels
   }
 
   return (
-    <Card data-test-id="status-card" className="co-overview-card--gradient">
+    <Card data-test-id="status-card">
       <CardHeader
         actions={{
           actions: (

--- a/frontend/public/components/dashboard/project-dashboard/activity-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/activity-card.tsx
@@ -147,7 +147,7 @@ export const ActivityCard: React.FC = () => {
   const viewEvents = `/k8s/ns/${projectName}/events`;
   const { t } = useTranslation();
   return (
-    <Card data-test-id="activity-card" className="co-overview-card--gradient">
+    <Card data-test-id="activity-card">
       <CardHeader
         actions={{
           actions: (

--- a/frontend/public/components/dashboard/project-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/status-card.tsx
@@ -36,7 +36,7 @@ export const StatusCard: React.FC = () => {
   const { t } = useTranslation();
 
   return (
-    <Card data-test-id="status-card" className="co-overview-card--gradient">
+    <Card data-test-id="status-card">
       <CardHeader>
         <CardTitle>{t('public~Status')}</CardTitle>
       </CardHeader>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -581,24 +581,6 @@ dl.co-inline {
   margin: 0 !important;
 }
 
-.co-overview-card--gradient {
-  position: relative;
-  &:after {
-    background: linear-gradient(
-      rgba(255, 255, 255, 0),
-      var(--pf-v6-c-page__main-section--BackgroundColor)
-    );
-    border-bottom-left-radius: var(--pf-v6-c-card--BorderRadius);
-    bottom: 1px;
-    content: '';
-    left: 1px;
-    min-height: 2rem;
-    pointer-events: none;
-    position: absolute;
-    width: calc(100% - var(--pf-t--global--spacer--lg));
-  }
-}
-
 .co-overview-card__actions {
   align-self: center !important;
 }


### PR DESCRIPTION
before:
(disappearing bottom border on wide screens)
![Screenshot 2025-01-14 at 14 49 37](https://github.com/user-attachments/assets/84d66aea-f318-4caf-bc53-54a91920a34d)

(fade out gradient problems)
<img width="517" alt="Screenshot 2025-01-15 at 19 27 04" src="https://github.com/user-attachments/assets/30ab005b-1f23-47d6-9968-da11bb8106e5" />

(border leaks)
<img width="638" alt="Screenshot 2025-01-15 at 18 03 10" src="https://github.com/user-attachments/assets/c6b28e2f-1eaa-43be-8ccc-e7ba45199fe3" />

after:
(disappearing bottom border on wide screens)
<img width="718" alt="Screenshot 2025-01-28 at 11 25 10" src="https://github.com/user-attachments/assets/ffa3981f-e910-40a0-819d-6b9fb849b325" />

(fade out gradient problems)
<img width="368" alt="Screenshot 2025-01-28 at 11 24 45" src="https://github.com/user-attachments/assets/66041e5f-1571-4050-aa18-c21e603c9173" />

(border leaks)

https://github.com/user-attachments/assets/1ecd104c-ba31-4c15-a9b1-343e2fc6f9ee


