### PR TITLE
fix(masthead): remove emphasis from masthead dropdowns 

### DIFF
--- a/frontend/packages/console-app/src/components/nav/ClusterMenuToggle.tsx
+++ b/frontend/packages/console-app/src/components/nav/ClusterMenuToggle.tsx
@@ -54,6 +54,7 @@ const ClusterMenuToggle = (props: {
       disabled={disabled}
       className="co-cluster-selector"
       data-test-id="cluster-dropdown-toggle"
+      variant="plainText"
     >
       {title}
     </MenuToggle>

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -586,6 +586,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
         toggle={(toggleRef) => (
           <MenuToggle
             aria-label={t('public~User menu')}
+            variant="plainText"
             ref={toggleRef}
             onClick={() => setIsUserDropdownOpen(!isUserDropdownOpen)}
             isExpanded={isUserDropdownOpen}
@@ -698,7 +699,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
                 <NotificationBadge
                   aria-label={t('public~Notification drawer')}
                   onClick={drawerToggle}
-                  variant="read"
+                  variant="plain"
                   count={alertCount || 0}
                   data-quickstart-id="qs-masthead-notifications"
                   className="co-masthead-button"
@@ -748,7 +749,7 @@ const MastheadToolbarContents = ({ consoleLinks, cv, isMastheadStacked }) => {
               <NotificationBadge
                 aria-label={t('public~Notification drawer')}
                 onClick={drawerToggle}
-                variant="read"
+                variant="plain"
                 count={alertCount}
                 data-quickstart-id="qs-masthead-notifications"
               >


### PR DESCRIPTION
Code-wise the PR is ready, but it is awaiting comments from design

before:
![image](https://github.com/user-attachments/assets/d141ae65-cc60-4051-9670-4d31a055b9ae)

after:
![image](https://github.com/user-attachments/assets/edd5c23d-680d-497b-a670-4016882c9b97)

pf5:
![image](https://github.com/user-attachments/assets/3600962c-caff-4182-ae40-33afdf478924)