### PR TITLE
fix visual regressions with quick search modal

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -21,12 +21,6 @@
         border-bottom: 0 !important;
       }
     }
-    &--highlight {
-      background-color: var(--pf-t--color--gray--10) !important;
-    }
-    &:hover {
-      background-color: var(--pf-t--color--gray--10);
-    }
   }
   &__item-row {
     padding: 0 var(--pf-t--global--spacer--sm) !important;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.scss
@@ -1,6 +1,14 @@
 .ocs-quick-search-modal {
   --pf-v6-c-modal-box--BackgroundColor: none !important;
   box-shadow: none !important;
+  border-radius: 0 !important;
+  max-width: unset !important;
+  max-height: unset !important;
+  inset-block: 0 !important;
+  height: 100% !important;
+  width: 100% !important;
+  overflow: hidden !important;
+
   &__no-backdrop {
     .pf-v6-c-backdrop {
       background: none;

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import { Modal, ModalVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { useBoundingClientRect } from '../../hooks';
 import { DetailsRendererFunction } from './QuickSearchDetails';
@@ -43,10 +43,7 @@ const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
       variant={ModalVariant.medium}
       aria-label={t('console-shared~Quick search')}
       isOpen={isOpen}
-      showClose={false}
       position="top"
-      positionOffset="15%"
-      hasNoBodyWrapper
       appendTo={viewContainer}
     >
       <QuickSearchModalBody


### PR DESCRIPTION
I'll look into following the PF6 design in a later PR, this one simply restores functionality

https://github.com/user-attachments/assets/9af4acfb-2d77-4965-a400-847bfa151859

