### PR TITLE
fix minor visual regressions with add modal

### DIFF
--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchContent.scss
@@ -4,6 +4,7 @@
   position: relative;
   &__list {
     height: 100%;
+    min-height: 350px;
     width: 40%;
   }
   &__details {

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.tsx
@@ -139,7 +139,11 @@ const QuickSearchList: React.FC<QuickSearchListProps> = ({
                         </SplitItem>
                         {item?.secondaryLabel && (
                           <SplitItem>
-                            <Label variant="outline">{item.secondaryLabel}</Label>
+                            {typeof item.secondaryLabel === 'string' ? (
+                              <Label variant="outline">{item.secondaryLabel}</Label>
+                            ) : (
+                              item.secondaryLabel
+                            )}
                           </SplitItem>
                         )}
                         <SplitItem>

--- a/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
+++ b/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-builder/PipelineBuilderForm.scss
@@ -13,9 +13,4 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  .ocs-quick-search-bar {
-    &__icon {
-      height: 1.5em;
-    }
-  }
 }


### PR DESCRIPTION
- `min-height` is applied to modal content so that the description is easier to read
- fixed a label inside of label bug that only exists in TektonHub labels deployed on a real cluster
- removed some more unused css

before:
![](https://i.imgur.com/WTjpNFT.png)

after:
![](https://i.imgur.com/lvCoZsp.png)