### PR TITLE
OCPBUGS-105789: Recover expired Playwright sessions via auto re-login

### DIFF
--- a/frontend/e2e/fixtures/auth-fixture.ts
+++ b/frontend/e2e/fixtures/auth-fixture.ts
@@ -1,0 +1,89 @@
+import type { Page, TestInfo } from '@playwright/test';
+
+import {
+  isOnLoginPage,
+  performLogin,
+  resolveCredentialsForStorageState,
+  saveStorageState,
+} from '../setup/login-helper';
+
+/**
+ * Guards against re-entrant / concurrent re-login attempts on the same page.
+ */
+const reloginInProgress = new WeakMap<Page, Promise<void>>();
+
+function storageStatePath(testInfo: TestInfo): string | undefined {
+  const state = testInfo.project.use.storageState;
+  return typeof state === 'string' ? state : undefined;
+}
+
+/**
+ * Detects when a navigation has landed on the OAuth login page — meaning the
+ * session snapshot in storageState has expired — and transparently
+ * re-authenticates the current persona, refreshing the stored session so
+ * subsequent tests reuse the fresh state.
+ *
+ * The setup projects establish the session once; long runs can outlive the
+ * OAuth token, after which every navigation silently redirects to the login
+ * page and tests hang waiting for elements that never appear. This fixture is
+ * the self-healing recovery for that case.
+ */
+export async function recoverSessionIfExpired(
+  page: Page,
+  testInfo: TestInfo,
+): Promise<boolean> {
+  if (!(await isOnLoginPage(page))) {
+    return false;
+  }
+
+  const existing = reloginInProgress.get(page);
+  if (existing) {
+    await existing;
+    return true;
+  }
+
+  const statePath = storageStatePath(testInfo);
+  const credentials = statePath ? resolveCredentialsForStorageState(statePath) : undefined;
+  if (!credentials) {
+    // No credentials to recover with (e.g. auth disabled or dev creds unset).
+    return false;
+  }
+
+  const relogin = (async () => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[auth] Session expired for "${testInfo.titlePath.join(' > ')}"; re-authenticating.`,
+    );
+    await performLogin(page, credentials.username, credentials.password, credentials.idpName);
+    if (statePath) {
+      await saveStorageState(page, statePath);
+    }
+  })();
+
+  reloginInProgress.set(page, relogin);
+  try {
+    await relogin;
+  } finally {
+    reloginInProgress.delete(page);
+  }
+  return true;
+}
+
+/**
+ * Attaches a main-frame navigation listener that re-authenticates whenever a
+ * navigation lands on the login page. Returns a disposer to detach it.
+ */
+export function attachSessionRecovery(page: Page, testInfo: TestInfo): () => void {
+  const handler = (frame: import('@playwright/test').Frame) => {
+    if (frame !== page.mainFrame()) {
+      return;
+    }
+    // Fire-and-forget: recovery guards its own re-entrancy. Swallow errors so a
+    // transient navigation event doesn't reject an unrelated step.
+    void recoverSessionIfExpired(page, testInfo).catch(() => {
+      /* best-effort recovery */
+    });
+  };
+  page.on('framenavigated', handler);
+  return () => page.off('framenavigated', handler);
+}

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -5,6 +5,7 @@ import { test as base, expect } from '@playwright/test';
 
 import KubernetesClient from '../clients/kubernetes-client';
 
+import { attachSessionRecovery, recoverSessionIfExpired } from './auth-fixture';
 import type { CleanupFixture } from './cleanup-fixture';
 import { createCleanupFixture } from './cleanup-fixture';
 
@@ -24,6 +25,21 @@ type WorkerFixtures = {
 };
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
+  // Override the built-in page fixture to transparently recover from expired
+  // sessions. Long runs can outlive the OAuth token captured in storageState;
+  // without this, navigations silently redirect to the login page and tests
+  // hang. The listener re-authenticates the persona whenever a navigation
+  // lands on the login page, and a proactive check covers the initial page.
+  page: async ({ page }, use, testInfo) => {
+    const detach = attachSessionRecovery(page, testInfo);
+    try {
+      await recoverSessionIfExpired(page, testInfo);
+      await use(page);
+    } finally {
+      detach();
+    }
+  },
+
   testConfig: [
     async ({}, use) => {
       const configPath = path.resolve(import.meta.dirname, '..', '.test-config.json');

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -33,6 +33,36 @@ export function getDeveloperCredentials(): {
   };
 }
 
+/**
+ * Resolves the login credentials for a given storage-state file. The auth
+ * fixture uses this to re-authenticate the correct persona (admin vs.
+ * developer) when a session expires mid-run, mirroring the setup projects.
+ * Returns null when the required credentials are not configured.
+ */
+export function resolveCredentialsForStorageState(
+  storageStatePath: string,
+): { username: string; password: string; idpName: string } | null {
+  const fileName = path.basename(storageStatePath);
+  if (fileName === 'developer.json') {
+    return getDeveloperCredentials();
+  }
+  // Default to the kubeadmin/admin persona.
+  return getAdminCredentials();
+}
+
+/**
+ * Returns true when the given page is currently showing the OAuth login page
+ * (i.e. the session has expired or was never established).
+ */
+export async function isOnLoginPage(page: Page): Promise<boolean> {
+  return page
+    .locator('[data-test-id="login"]')
+    .or(page.locator('#inputUsername'))
+    .first()
+    .isVisible()
+    .catch(() => false);
+}
+
 export async function performLogin(
   page: Page,
   username: string,


### PR DESCRIPTION
**Analysis / Root cause**:

The Playwright e2e suite authenticates exactly once, in the setup projects ([`admin-auth.setup.ts`](frontend/e2e/setup/admin-auth.setup.ts), [`developer-auth.setup.ts`](frontend/e2e/setup/developer-auth.setup.ts)), and freezes the session into a `storageState` snapshot. Every test project loads that static snapshot ([`playwright.config.ts`](frontend/playwright.config.ts)) and nothing ever re-authenticates — `performLogin` is only referenced by the two setup files.

When the OpenShift OAuth token expires during a long run, subsequent `page.goto()` calls silently redirect to the login page, and tests hang waiting for elements (e.g. `user-dropdown-toggle`, `#page-sidebar`) that never appear, failing with generic `toBeVisible`/test-timeout errors. This showed up as widespread login-page hangs in CI.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-105789

**Solution description**:

Add a self-healing auth fixture that overrides Playwright's built-in `page` fixture:

- [`e2e/fixtures/auth-fixture.ts`](frontend/e2e/fixtures/auth-fixture.ts) (new) — attaches a main-frame `framenavigated` listener that detects when a navigation lands on the login page and transparently re-runs `performLogin` for the active persona, then re-saves `storageState` so later tests reuse the fresh session. Re-entrancy is guarded via a `WeakMap` so the login flow's own navigations don't recurse, and it logs a warning when recovery fires so future occurrences are visible in CI logs.
- [`e2e/setup/login-helper.ts`](frontend/e2e/setup/login-helper.ts) — adds `isOnLoginPage()` and `resolveCredentialsForStorageState()` (dispatches to the existing `getAdminCredentials()`/`getDeveloperCredentials()` helpers based on the project's storage-state filename).
- [`e2e/fixtures/index.ts`](frontend/e2e/fixtures/index.ts) — wires recovery into the shared `page` fixture. Since every spec imports `test` from here, coverage is suite-wide with no per-test changes.

Auth-disabled clusters and unset developer credentials cause recovery to no-op safely.

> **Note:** This PR is based on `OCPBUGS-105609` (not yet merged) because that branch refactors the same setup/login helpers. It targets the `OCPBUGS-105609` branch so the diff shows only this change; it will be retargeted to `main` once OCPBUGS-105609 merges.

**Screenshots / screen recording**:
<!-- N/A — test-infrastructure change, no UI impact -->

**Test setup:**

Requires a cluster whose OAuth access-token lifetime is shorter than the full e2e run so the session expires mid-run; the recovery path then re-authenticates transparently.

**Test cases:**

- Full Playwright e2e run outlasting the OAuth token: post-expiry tests recover instead of hanging on the login page.
- Admin and developer personas each re-authenticate with the correct credentials.
- Auth-disabled cluster: recovery no-ops, tests unaffected.
- Unset developer credentials: recovery no-ops without error.

**Browser conformance**:
- [x] Chrome

**Additional info:**

Test-infrastructure only — no product/runtime code changes.

**Reviewers and assignees:**
<!-- Tag an OCP console engineer to review. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
